### PR TITLE
Add icons for folders vs files

### DIFF
--- a/app/src/main/java/uk/ac/cam/cl/juliet/adapters/FilesListAdapter.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/adapters/FilesListAdapter.java
@@ -60,6 +60,15 @@ public class FilesListAdapter extends RecyclerView.Adapter<FilesListAdapter.File
         filesListViewHolder.getTimestampTextView().setText(file.timestamp);
         filesListViewHolder.getGpsTextView().setText(file.gps);
         filesListViewHolder.getUploadingSpinner().setVisibility(View.INVISIBLE);
+        if (file.isIndividualFile) {
+            filesListViewHolder
+                    .getTypeImageView()
+                    .setImageResource(R.drawable.baseline_show_chart_black_36);
+        } else {
+            filesListViewHolder
+                    .getTypeImageView()
+                    .setImageResource(R.drawable.baseline_folder_black_36);
+        }
         if (file.syncStatus) {
             filesListViewHolder
                     .getSyncStatusImageView()
@@ -94,6 +103,7 @@ public class FilesListAdapter extends RecyclerView.Adapter<FilesListAdapter.File
         private View container;
         private TextView timestampTextView;
         private TextView gpsTextView;
+        private ImageView typeImageView;
         private ImageView syncStatusImageView;
         private ProgressBar uploadingSpinner;
 
@@ -102,6 +112,7 @@ public class FilesListAdapter extends RecyclerView.Adapter<FilesListAdapter.File
             container = itemView;
             timestampTextView = itemView.findViewById(R.id.timestampTextView);
             gpsTextView = itemView.findViewById(R.id.gpsTextView);
+            typeImageView = itemView.findViewById(R.id.typeIcon);
             syncStatusImageView = itemView.findViewById(R.id.syncStatusImageView);
             uploadingSpinner = itemView.findViewById(R.id.uploadingSpinner);
         }
@@ -134,6 +145,10 @@ public class FilesListAdapter extends RecyclerView.Adapter<FilesListAdapter.File
 
         public TextView getGpsTextView() {
             return gpsTextView;
+        }
+
+        public ImageView getTypeImageView() {
+            return typeImageView;
         }
 
         public ImageView getSyncStatusImageView() {

--- a/app/src/main/java/uk/ac/cam/cl/juliet/adapters/FilesListAdapter.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/adapters/FilesListAdapter.java
@@ -27,7 +27,24 @@ public class FilesListAdapter extends RecyclerView.Adapter<FilesListAdapter.File
      * displayed when a file is selected.
      */
     public interface OnDataFileSelectedListener {
+
+        /**
+         * Invoked when a file or folder in the list is clicked.
+         *
+         * @param file The file that was clicked
+         * @param viewHolder The ViewHolder containing all UI elements in that row
+         */
         void onDataFileClicked(
+                DataFragment.TemporaryDataFileType file, FilesListViewHolder viewHolder);
+
+        /**
+         * Invoked when a file or folder in the list is long clicked.
+         *
+         * @param file The file that was long clicked
+         * @param viewHolder The ViewHolder containing all UI elements in that row
+         * @return true if the long click was consumed; false otherwise
+         */
+        boolean onDataFileLongClicked(
                 DataFragment.TemporaryDataFileType file, FilesListViewHolder viewHolder);
     }
 
@@ -72,11 +89,11 @@ public class FilesListAdapter extends RecyclerView.Adapter<FilesListAdapter.File
         if (file.syncStatus) {
             filesListViewHolder
                     .getSyncStatusImageView()
-                    .setImageResource(R.drawable.baseline_cloud_done_black_24);
+                    .setImageResource(R.drawable.baseline_cloud_done_black_18);
         } else {
             filesListViewHolder
                     .getSyncStatusImageView()
-                    .setImageResource(R.drawable.baseline_cloud_off_black_24);
+                    .setImageResource(R.drawable.baseline_cloud_off_black_18);
         }
         filesListViewHolder.setSpinnerVisibility(false);
         filesListViewHolder
@@ -86,6 +103,15 @@ public class FilesListAdapter extends RecyclerView.Adapter<FilesListAdapter.File
                             @Override
                             public void onClick(View v) {
                                 listener.onDataFileClicked(file, filesListViewHolder);
+                            }
+                        });
+        filesListViewHolder
+                .getContainer()
+                .setOnLongClickListener(
+                        new View.OnLongClickListener() {
+                            @Override
+                            public boolean onLongClick(View v) {
+                                return listener.onDataFileLongClicked(file, filesListViewHolder);
                             }
                         });
     }

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
@@ -9,7 +9,6 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v7.app.AlertDialog;
-import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
@@ -43,11 +42,14 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
         public String timestamp;
         public String gps;
         public boolean syncStatus;
+        public boolean isIndividualFile;
 
-        public TemporaryDataFileType(String timestamp, String gps, boolean syncStatus) {
+        public TemporaryDataFileType(
+                String timestamp, String gps, boolean syncStatus, boolean isIndividualFile) {
             this.timestamp = timestamp;
             this.gps = gps;
             this.syncStatus = syncStatus;
+            this.isIndividualFile = isIndividualFile;
         }
     }
 
@@ -61,9 +63,9 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
         View view = inflater.inflate(R.layout.fragment_data, container, false);
         filesList = view.findViewById(R.id.filesListRecyclerView);
         filesList.setLayoutManager(new LinearLayoutManager(getContext()));
-        DividerItemDecoration divider =
-                new DividerItemDecoration(context, DividerItemDecoration.VERTICAL);
-        filesList.addItemDecoration(divider);
+        //        DividerItemDecoration divider =
+        //                new DividerItemDecoration(context, DividerItemDecoration.VERTICAL);
+        //        filesList.addItemDecoration(divider);
         ArrayList<TemporaryDataFileType> files = getDataFiles();
         adapter = new FilesListAdapter(files);
         adapter.setOnDataFileSelectedListener(this);
@@ -151,9 +153,9 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
     private ArrayList<TemporaryDataFileType> getDataFiles() {
         // TODO: Actually load data files!
         ArrayList<TemporaryDataFileType> files = new ArrayList<>();
-        files.add(new TemporaryDataFileType("31/1/2019", "GPS location here", false));
-        files.add(new TemporaryDataFileType("30/1/2019", "GPS location here", true));
-        files.add(new TemporaryDataFileType("29/1/2019", "GPS location here", true));
+        files.add(new TemporaryDataFileType("31/1/2019", "GPS location here", false, true));
+        files.add(new TemporaryDataFileType("30/1/2019", "GPS location here", true, false));
+        files.add(new TemporaryDataFileType("29/1/2019", "GPS location here", true, true));
         return files;
     }
 

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
@@ -3,10 +3,12 @@ package uk.ac.cam.cl.juliet.fragments;
 import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.widget.DividerItemDecoration;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
@@ -116,6 +118,7 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
                             @Override
                             public void onClick(View v) {
                                 dialog.cancel();
+                                showConfirmDeleteDialog();
                             }
                         });
         dialog.findViewById(R.id.syncButton)
@@ -180,6 +183,33 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
                             }
                         });
         dialog.show();
+    }
+
+    /** Shows a dialog message to confirm whether a file or folder should be deleted. */
+    private void showConfirmDeleteDialog() {
+        Context context = getContext();
+        if (context == null) return;
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(R.string.confirm_delete);
+        builder.setMessage(R.string.are_you_sure_delete);
+        builder.setPositiveButton(
+                R.string.delete,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        // TODO: delete the file
+                        dialog.cancel();
+                    }
+                });
+        builder.setNegativeButton(
+                R.string.cancel,
+                new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int which) {
+                        dialog.cancel();
+                    }
+                });
+        builder.create().show();
     }
 
     /**

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
@@ -112,37 +112,52 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
             final FilesListAdapter.FilesListViewHolder viewHolder) {
         Context context = getContext();
         if (context == null) return;
-        final Dialog dialog = new Dialog(context);
-        dialog.setContentView(R.layout.dialog_file_selected);
-        dialog.findViewById(R.id.deleteButton)
-                .setOnClickListener(
-                        new Button.OnClickListener() {
+        if (file.isIndividualFile) {
+            Toast.makeText(context, "Display the file.", Toast.LENGTH_SHORT).show();
+        } else {
+            Toast.makeText(context, "Display folder contents.", Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    @Override
+    public boolean onDataFileLongClicked(
+            final TemporaryDataFileType file,
+            final FilesListAdapter.FilesListViewHolder viewHolder) {
+        Context context = getContext();
+        if (context == null) return false;
+        int titleRes = (file.isIndividualFile) ? R.string.file_selected : R.string.folder_selected;
+        AlertDialog.Builder builder = new AlertDialog.Builder(context);
+        builder.setTitle(titleRes)
+                .setMessage(R.string.what_do_with_file)
+                .setPositiveButton(
+                        "Sync",
+                        new DialogInterface.OnClickListener() {
                             @Override
-                            public void onClick(View v) {
+                            public void onClick(DialogInterface dialog, int which) {
                                 dialog.cancel();
-                                showConfirmDeleteDialog();
-                            }
-                        });
-        dialog.findViewById(R.id.syncButton)
-                .setOnClickListener(
-                        new Button.OnClickListener() {
-                            @Override
-                            public void onClick(View v) {
-                                // TODO: sync the file to the server
                                 uploadFile(file, viewHolder);
-                                dialog.cancel();
                             }
-                        });
-        dialog.findViewById(R.id.displayButton)
-                .setOnClickListener(
-                        new Button.OnClickListener() {
+                        })
+                .setNeutralButton(
+                        "Delete",
+                        new DialogInterface.OnClickListener() {
                             @Override
-                            public void onClick(View v) {
-                                // TODO: display the file's data
+                            public void onClick(DialogInterface dialog, int which) {
+                                dialog.cancel();
+                                showConfirmDeleteDialog(file);
+                            }
+                        })
+                .setNegativeButton(
+                        "Cancel",
+                        new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int which) {
                                 dialog.cancel();
                             }
-                        });
-        dialog.show();
+                        })
+                .create()
+                .show();
+        return true;
     }
 
     /**
@@ -188,7 +203,7 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
     }
 
     /** Shows a dialog message to confirm whether a file or folder should be deleted. */
-    private void showConfirmDeleteDialog() {
+    private void showConfirmDeleteDialog(TemporaryDataFileType file) {
         Context context = getContext();
         if (context == null) return;
         AlertDialog.Builder builder = new AlertDialog.Builder(context);

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
@@ -63,9 +63,6 @@ public class DataFragment extends Fragment implements FilesListAdapter.OnDataFil
         View view = inflater.inflate(R.layout.fragment_data, container, false);
         filesList = view.findViewById(R.id.filesListRecyclerView);
         filesList.setLayoutManager(new LinearLayoutManager(getContext()));
-        //        DividerItemDecoration divider =
-        //                new DividerItemDecoration(context, DividerItemDecoration.VERTICAL);
-        //        filesList.addItemDecoration(divider);
         ArrayList<TemporaryDataFileType> files = getDataFiles();
         adapter = new FilesListAdapter(files);
         adapter.setOnDataFileSelectedListener(this);

--- a/app/src/main/res/layout/listelement_data_file.xml
+++ b/app/src/main/res/layout/listelement_data_file.xml
@@ -50,7 +50,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        app:srcCompat="@drawable/baseline_sync_black_48" />
+        app:srcCompat="@drawable/baseline_cloud_done_black_18" />
 
     <ProgressBar
         android:id="@+id/uploadingSpinner"

--- a/app/src/main/res/layout/listelement_data_file.xml
+++ b/app/src/main/res/layout/listelement_data_file.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -18,7 +19,7 @@
         android:textAppearance="@style/TextAppearance.AppCompat.SearchResult.Title"
         app:layout_constraintBottom_toTopOf="@+id/gpsTextView"
         app:layout_constraintEnd_toStartOf="@+id/syncStatusImageView"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/typeIcon"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="spread_inside" />
 
@@ -35,7 +36,7 @@
         android:text="GPS stuff here"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/syncStatusImageView"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/typeIcon"
         app:layout_constraintTop_toBottomOf="@+id/timestampTextView" />
 
     <ImageView
@@ -62,4 +63,17 @@
         app:layout_constraintEnd_toEndOf="@+id/syncStatusImageView"
         app:layout_constraintStart_toStartOf="@+id/syncStatusImageView"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/typeIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginLeft="24dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/baseline_show_chart_black_36" />
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,4 +15,7 @@
     <string name="delete">Delete</string>
     <string name="overview">Overview</string>
     <string name="detail">Detail</string>
+    <string name="cancel">Cancel</string>
+    <string name="confirm_delete">Confirm deletion</string>
+    <string name="are_you_sure_delete">Are you sure you want to delete the file?</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -10,6 +10,7 @@
     <string name="tab_details">Details</string>
     <string name="sync">Sync</string>
     <string name="file_selected">File selected</string>
+    <string name="folder_selected">Folder selected</string>
     <string name="what_do_with_file">What do you want to do with this file?</string>
     <string name="display">Display</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION
The list of files now has a folder/file icon on the left hand side accordingly.

![screenshot_1549558011](https://user-images.githubusercontent.com/13272874/52427533-05daeb80-2af8-11e9-8332-4958ebba849b.png)

I also reworked the UI flow: a normal click takes you directly to viewing a file/folder, while a long-press brings up a dialog with options for deletion and syncing.
