### PR TITLE
Restructure file tree loading

### DIFF
--- a/app/src/main/java/uk/ac/cam/cl/juliet/activities/MainActivity.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/activities/MainActivity.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import uk.ac.cam.cl.juliet.R;
 import uk.ac.cam.cl.juliet.data.AuthenticationManager;
-import uk.ac.cam.cl.juliet.fragments.DataFragment;
 import uk.ac.cam.cl.juliet.fragments.DataFragmentWrapper;
 import uk.ac.cam.cl.juliet.fragments.DisplayFragment;
 import uk.ac.cam.cl.juliet.fragments.SettingsFragment;
@@ -50,10 +49,7 @@ public class MainActivity extends AppCompatActivity
 
         // Create an instance of each fragment
         displayFragment = new DisplayFragment();
-        Bundle dataFragmentArgs = new Bundle();
-        dataFragmentArgs.putBoolean(DataFragment.TOP_LEVEL, true);
         dataFragment = new DataFragmentWrapper();
-        dataFragment.setArguments(dataFragmentArgs);
         settingsFragment = new SettingsFragment();
 
         // Set up a ViewPager to handle displaying the three Fragments

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
@@ -169,11 +169,12 @@ public class DataFragment extends Fragment
             final SingleOrManyBursts file, final FilesListAdapter.FilesListViewHolder viewHolder) {
         Context context = getContext();
         if (context == null) return false;
-        int titleRes =
-                (file.getIsSingleBurst()) ? R.string.file_selected : R.string.folder_selected;
+        int titleRes = file.getFile().isFile() ? R.string.file_selected : R.string.folder_selected;
+        int messageRes =
+                file.getFile().isFile() ? R.string.what_do_with_file : R.string.what_do_with_folder;
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         builder.setTitle(titleRes)
-                .setMessage(R.string.what_do_with_file)
+                .setMessage(messageRes)
                 .setPositiveButton(
                         R.string.sync,
                         new DialogInterface.OnClickListener() {

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
@@ -295,18 +295,23 @@ public class DataFragment extends Fragment
     }
 
     /** Shows a dialog message to confirm whether a file or folder should be deleted. */
-    private void showConfirmDeleteDialog(SingleOrManyBursts file) {
+    private void showConfirmDeleteDialog(final SingleOrManyBursts file) {
         Context context = getContext();
         if (context == null) return;
         AlertDialog.Builder builder = new AlertDialog.Builder(context);
         builder.setTitle(R.string.confirm_delete);
-        builder.setMessage(R.string.are_you_sure_delete);
+        int messageResource =
+                file.getFile().isFile()
+                        ? R.string.are_you_sure_delete_file
+                        : R.string.are_you_sure_delete_folder;
+        builder.setMessage(messageResource);
         builder.setPositiveButton(
                 R.string.delete,
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialog, int which) {
-                        // TODO: delete the file
+                        deleteFileOrFolder(file.getFile());
+                        refreshFiles();
                         dialog.cancel();
                     }
                 });
@@ -319,6 +324,25 @@ public class DataFragment extends Fragment
                     }
                 });
         builder.create().show();
+    }
+
+    /**
+     * Deletes the passed file.
+     *
+     * <p>If the passed file is a folder, then this will recursively delete everything inside the
+     * folder before deleting the folder itself.
+     *
+     * @param fileOrFolder The file (or folder) to delete
+     */
+    private void deleteFileOrFolder(File fileOrFolder) {
+        if (fileOrFolder.isFile()) {
+            fileOrFolder.delete();
+        } else {
+            for (File f : fileOrFolder.listFiles()) {
+                deleteFileOrFolder(f);
+            }
+            fileOrFolder.delete();
+        }
     }
 
     /**

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragment.java
@@ -17,6 +17,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ProgressBar;
 import android.widget.TextView;
 import java.io.File;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ public class DataFragment extends Fragment
     private RecyclerView filesRecyclerView;
     private TextView noFilesToDisplayText;
     private FilesListAdapter adapter;
+    private ProgressBar loadingFilesSpinner;
 
     private File currentDirectory;
     private SingleOrManyBursts currentNode;
@@ -85,6 +87,10 @@ public class DataFragment extends Fragment
         noFilesToDisplayText = view.findViewById(R.id.noFilesText);
         setNoFilesMessageVisibility(false);
 
+        // Find the files loading spinner
+        loadingFilesSpinner = view.findViewById(R.id.loadingFilesProgressSpinner);
+        loadingFilesSpinner.setVisibility(View.INVISIBLE);
+
         // Set up and potentially disable the "plot all files" button
         plotAllFilesButton = view.findViewById(R.id.displayAllFilesButton);
         if (!getEligibleForPlottingAllFiles()) {
@@ -104,6 +110,9 @@ public class DataFragment extends Fragment
     public void onResume() {
         super.onResume();
         refreshFiles();
+        if (listener != null) {
+            listener.notifyIsActiveFragment(this);
+        }
     }
 
     /**
@@ -391,7 +400,8 @@ public class DataFragment extends Fragment
         @Override
         protected void onPreExecute() {
             super.onPreExecute();
-            // TODO: Show a "loading" spinner + message
+            dataFragment.loadingFilesSpinner.setVisibility(View.VISIBLE);
+            dataFragment.filesRecyclerView.setVisibility(View.INVISIBLE);
         }
 
         @Override
@@ -422,7 +432,8 @@ public class DataFragment extends Fragment
             dataFragment.updatePlotAllFilesButtonEnabled();
             dataFragment.adapter.notifyDataSetChanged();
             dataFragment.setNoFilesMessageVisibility(dataFragment.filesList.isEmpty());
-            // TODO: Hide "loading" spinner + message
+            dataFragment.loadingFilesSpinner.setVisibility(View.INVISIBLE);
+            dataFragment.filesRecyclerView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -431,11 +442,27 @@ public class DataFragment extends Fragment
      * display the contents of the folder that was selected.
      */
     public interface DataFragmentListener {
+
+        /**
+         * Instructs the container to show the chosen folder.
+         *
+         * @param innerFolder The folder to display
+         */
         void onInnerFolderClicked(SingleOrManyBursts innerFolder);
 
+        /**
+         * Instructs the container to upload the chosen file.
+         *
+         * @param parent The DataFragment containing this fragment // TODO: Why is this here?
+         * @param viewHolder The ViewHolder for the row that was selected
+         * @param file The file that is to be uploaded
+         */
         void uploadFile(
                 DataFragment parent,
                 FilesListAdapter.FilesListViewHolder viewHolder,
                 SingleOrManyBursts file);
+
+        /** Notifies the container that this fragment is now the active one */
+        void notifyIsActiveFragment(DataFragment activeFragment);
     }
 }

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragmentWrapper.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragmentWrapper.java
@@ -52,7 +52,7 @@ public class DataFragmentWrapper extends Fragment
 
     private MenuItem signIn;
     private MenuItem signOut;
-
+    private DataFragment currentFragment;
     private User user;
 
     @Nullable
@@ -65,12 +65,15 @@ public class DataFragmentWrapper extends Fragment
         setHasOptionsMenu(true);
         Bundle arguments = new Bundle();
         arguments.putString(DataFragment.FOLDER_PATH, getRootPath());
-        DataFragment dataFragment = new DataFragment();
-        dataFragment.setArguments(arguments);
-        dataFragment.setDataFragmentListener(this);
+        currentFragment = new DataFragment();
+        currentFragment.setArguments(arguments);
+        currentFragment.setDataFragmentListener(this);
         FragmentManager fragmentManager = getFragmentManager();
         if (fragmentManager != null) {
-            fragmentManager.beginTransaction().add(R.id.dataFragmentContent, dataFragment).commit();
+            fragmentManager
+                    .beginTransaction()
+                    .add(R.id.dataFragmentContent, currentFragment)
+                    .commit();
         }
         return view;
     }
@@ -95,6 +98,7 @@ public class DataFragmentWrapper extends Fragment
             case R.id.refresh:
                 // TODO: Update files in the DataFragment
                 Log.d("DataFragmentWrapper", "Update your files!");
+                currentFragment.refreshFiles();
                 return true;
             case R.id.sign_in_button:
                 // Handling Microsoft connection
@@ -164,16 +168,16 @@ public class DataFragmentWrapper extends Fragment
     public void onInnerFolderClicked(SingleOrManyBursts innerFolder) {
         if (innerFolder.getIsSingleBurst()) return; // Should not happen...
 
-        DataFragment innerFragment = new DataFragment();
+        currentFragment = new DataFragment();
         Bundle arguments = new Bundle();
         arguments.putString(FOLDER_PATH, innerFolder.getFile().getAbsolutePath());
-        innerFragment.setArguments(arguments);
-        innerFragment.setDataFragmentListener(this);
+        currentFragment.setArguments(arguments);
+        currentFragment.setDataFragmentListener(this);
         FragmentManager fragmentManager = getFragmentManager();
         if (fragmentManager != null) {
             fragmentManager
                     .beginTransaction()
-                    .replace(R.id.dataFragmentContent, innerFragment, innerFragment.getTag())
+                    .replace(R.id.dataFragmentContent, currentFragment, currentFragment.getTag())
                     .addToBackStack(null)
                     .commit();
         }

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragmentWrapper.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragmentWrapper.java
@@ -1,13 +1,19 @@
 package uk.ac.cam.cl.juliet.fragments;
 
+import static uk.ac.cam.cl.juliet.fragments.DataFragment.FOLDER_PATH;
+
+import android.Manifest;
+import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.content.ContextCompat;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -57,8 +63,10 @@ public class DataFragmentWrapper extends Fragment
             @Nullable Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.fragment_data_wrapper, container, false);
         setHasOptionsMenu(true);
+        Bundle arguments = new Bundle();
+        arguments.putString(DataFragment.FOLDER_PATH, getRootPath());
         DataFragment dataFragment = new DataFragment();
-        dataFragment.setArguments(getArguments());
+        dataFragment.setArguments(arguments);
         dataFragment.setDataFragmentListener(this);
         FragmentManager fragmentManager = getFragmentManager();
         if (fragmentManager != null) {
@@ -106,6 +114,21 @@ public class DataFragmentWrapper extends Fragment
         return false;
     }
 
+    private String getRootPath() {
+        InternalDataHandler idh = InternalDataHandler.getInstance();
+        Activity activity = getActivity();
+        String path = null;
+        if (activity != null
+                && ContextCompat.checkSelfPermission(
+                                activity, Manifest.permission.READ_EXTERNAL_STORAGE)
+                        == PackageManager.PERMISSION_GRANTED) {
+            path = idh.getRoot().getAbsolutePath();
+        } else {
+            // TODO: Show error message; we failed to get permissions
+        }
+        return path;
+    }
+
     /**
      * A method for checking the current authentication status and setting the correct sign in or
      * out buttons
@@ -143,8 +166,7 @@ public class DataFragmentWrapper extends Fragment
 
         DataFragment innerFragment = new DataFragment();
         Bundle arguments = new Bundle();
-        arguments.putBoolean(DataFragment.TOP_LEVEL, false);
-        arguments.putSerializable(DataFragment.FILES_LIST, innerFolder);
+        arguments.putString(FOLDER_PATH, innerFolder.getFile().getAbsolutePath());
         innerFragment.setArguments(arguments);
         innerFragment.setDataFragmentListener(this);
         FragmentManager fragmentManager = getFragmentManager();

--- a/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragmentWrapper.java
+++ b/app/src/main/java/uk/ac/cam/cl/juliet/fragments/DataFragmentWrapper.java
@@ -229,6 +229,11 @@ public class DataFragmentWrapper extends Fragment
         // TODO: implement
     }
 
+    @Override
+    public void notifyIsActiveFragment(DataFragment activeFragment) {
+        currentFragment = activeFragment;
+    }
+
     /** Begins the authentication process with Microsoft */
     private void connect() {
         // Get the Authentication Manager Instance

--- a/app/src/main/res/layout/fragment_data.xml
+++ b/app/src/main/res/layout/fragment_data.xml
@@ -7,6 +7,19 @@
     android:layout_height="match_parent"
     android:layout_width="match_parent">
 
+    <ProgressBar
+        android:id="@+id/loadingFilesProgressSpinner"
+        style="@android:style/Widget.DeviceDefault.Light.ProgressBar.Large"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="8dp"
+        android:layout_marginBottom="8dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
     <TextView
         android:id="@+id/noFilesText"
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,6 +13,7 @@
     <string name="file_selected">File selected</string>
     <string name="folder_selected">Folder selected</string>
     <string name="what_do_with_file">What do you want to do with this file?</string>
+    <string name="what_do_with_folder">What do you want to do with this folder?</string>
     <string name="display">Display</string>
     <string name="delete">Delete</string>
     <string name="overview">Overview</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,7 +19,8 @@
     <string name="detail">Detail</string>
     <string name="cancel">Cancel</string>
     <string name="confirm_delete">Confirm deletion</string>
-    <string name="are_you_sure_delete">Are you sure you want to delete the file?</string>
+    <string name="are_you_sure_delete_file">Are you sure you want to delete the file?</string>
+    <string name="are_you_sure_delete_folder">Are you sure you want to delete the folder?</string>
     <string name="connect_btn">Connect</string>
     <string name="send_btn">Send</string>
     <string name="sign_in">Sign in</string>


### PR DESCRIPTION
File names and folders now only load on demand, rather than pre-traversing the whole tree on launch. This also happens asynchronously, and a spinner is shown in the process.